### PR TITLE
Make Controller UI Camera properly follow controller transform

### DIFF
--- a/Assets/ViveControllerInput.cs
+++ b/Assets/ViveControllerInput.cs
@@ -51,7 +51,9 @@ public class ViveControllerInput : BaseInputModule
             ControllerCamera = new GameObject("Controller UI Camera").AddComponent<Camera>();
             ControllerCamera.clearFlags = CameraClearFlags.Nothing; //CameraClearFlags.Depth;
             ControllerCamera.cullingMask = 0; // 1 << LayerMask.NameToLayer("UI");
+#if UNITY_5_4_OR_NEWER
             ControllerCamera.stereoTargetEye = StereoTargetEyeMask.None;
+#endif
 
             ControllerManager = GameObject.FindObjectOfType<SteamVR_ControllerManager>();
             Controllers = new SteamVR_TrackedObject[] { ControllerManager.left.GetComponent<SteamVR_TrackedObject>(), ControllerManager.right.GetComponent<SteamVR_TrackedObject>() };

--- a/Assets/ViveControllerInput.cs
+++ b/Assets/ViveControllerInput.cs
@@ -50,7 +50,8 @@ public class ViveControllerInput : BaseInputModule
 
             ControllerCamera = new GameObject("Controller UI Camera").AddComponent<Camera>();
             ControllerCamera.clearFlags = CameraClearFlags.Nothing; //CameraClearFlags.Depth;
-            ControllerCamera.cullingMask = 0; // 1 << LayerMask.NameToLayer("UI"); 
+            ControllerCamera.cullingMask = 0; // 1 << LayerMask.NameToLayer("UI");
+            ControllerCamera.stereoTargetEye = StereoTargetEyeMask.None;
 
             ControllerManager = GameObject.FindObjectOfType<SteamVR_ControllerManager>();
             Controllers = new SteamVR_TrackedObject[] { ControllerManager.left.GetComponent<SteamVR_TrackedObject>(), ControllerManager.right.GetComponent<SteamVR_TrackedObject>() };


### PR DESCRIPTION
In Unity 5.4.0b21 I found that by default the "Controller UI Camera" used as a source of raycasts wasn't correctly following the hand controller transform(s) since it was tracking the HMD by default. Setting Camera.stereoTargetEye to None on the "Controller UI Camera" fixes this (conditionally compiled for versions 5.4+ since this property doesn't exist in Unity 5.3).
